### PR TITLE
All Tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+# .github/workflows/ci.yml
+
+name: CI Pipeline
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  k8s-test:
+    name: Kubernetes Test Suite
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 1: Checkout PR code
+      - name: 🧾 Checkout code
+        uses: actions/checkout@v3
+
+      # Step 2: Install KinD and kubectl
+      - name: ⚙️ Install KinD and kubectl
+        run: |
+          echo "🔧 Installing KinD..."
+          curl -L "https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-amd64" -o kind
+          chmod +x kind && sudo mv kind /usr/local/bin/kind
+
+          echo "🔧 Installing kubectl..."
+          curl -LO "https://dl.k8s.io/release/v1.32.3/bin/linux/amd64/kubectl"
+          chmod +x kubectl && sudo mv kubectl /usr/local/bin/kubectl
+
+          echo "✅ KinD and kubectl installed!"
+
+      # Step 3: Create multi-node KinD cluster using config
+      - name: 🏗️ Create KinD cluster
+        run: kind create cluster --config cluster/kind-config.yaml
+
+      # Step 4: Verify cluster connectivity
+      - name: 🔍 Check Kubernetes cluster status
+        run: kubectl cluster-info
+
+      # Step 5: Deploy NGINX Ingress Controller
+      - name: 🌐 Deploy NGINX Ingress Controller
+        run: |
+          kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.9.4/deploy/static/provider/kind/deploy.yaml
+
+          echo "⏳ Waiting for ingress-nginx-controller pod to be ready..."
+          kubectl wait --namespace ingress-nginx \
+            --for=condition=ready pod \
+            --selector=app.kubernetes.io/component=controller \
+            --timeout=300s || {
+              echo "❌ Timed out waiting for ingress controller. Dumping pod status:"
+              kubectl get pods -n ingress-nginx -o wide
+              kubectl describe pods -n ingress-nginx
+              kubectl logs -n ingress-nginx -l app.kubernetes.io/component=controller || true
+              exit 1
+            }
+
+      # Step 6: Deploy applications and ingress config
+      - name: 🚀 Deploy echo services and ingress
+        run: kubectl apply -f manifests/
+
+      # Step 7: Wait for application readiness
+      - name: ✅ Wait for application deployments to be ready
+        run: |
+          kubectl wait --for=condition=available --timeout=90s deployment/foo
+          kubectl wait --for=condition=available --timeout=90s deployment/bar
+
+      # Step 8: Run load test with k6
+      - name: 📊 Run load testing with k6
+        run: |
+          curl -s https://downloads.k6.io/releases/0.47.0/k6-v0.47.0-linux-amd64.tar.gz | tar xz
+          ./k6-v0.47.0-linux-amd64/k6 run scripts/loadtest.js | tee result.txt
+
+      # Step 9: Post results as a comment on the pull request
+      - name: 💬 Comment load test results on PR
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ## 🚀 Load Testing Report
+            ```
+            $(cat result.txt)
+            ```

--- a/cluster/kind-config.yaml
+++ b/cluster/kind-config.yaml
@@ -1,0 +1,5 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+  - role: worker

--- a/manifests/bar.yaml
+++ b/manifests/bar.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bar
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bar
+  template:
+    metadata:
+      labels:
+        app: bar
+    spec:
+      containers:
+      - name: bar
+        image: ealen/echo-server
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bar
+spec:
+  selector:
+    app: bar
+  ports:
+    - port: 80
+      targetPort: 80

--- a/manifests/foo.yaml
+++ b/manifests/foo.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: foo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: foo
+  template:
+    metadata:
+      labels:
+        app: foo
+    spec:
+      containers:
+      - name: foo
+        image: ealen/echo-server
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: foo
+spec:
+  selector:
+    app: foo
+  ports:
+    - port: 80
+      targetPort: 80

--- a/manifests/ingress.yaml
+++ b/manifests/ingress.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: echo-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+    - host: foo.localhost
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: foo
+                port:
+                  number: 80
+    - host: bar.localhost
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: bar
+                port:
+                  number: 80

--- a/scripts/loadtest.js
+++ b/scripts/loadtest.js
@@ -1,0 +1,21 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export let options = {
+  vus: 20,
+  duration: '15s',
+};
+
+export default function () {
+  const hosts = ['foo.localhost', 'bar.localhost'];
+  const target = hosts[Math.floor(Math.random() * hosts.length)];
+  let res = http.get('http://' + target, {
+    headers: { Host: target },
+  });
+
+  check(res, {
+    'status is 200': (r) => r.status === 200,
+  });
+
+  sleep(1);
+}


### PR DESCRIPTION
Add Kubernetes CI Pipeline with Load Testing

This PR sets up a full CI pipeline using GitHub Actions that provisions a KinD-based Kubernetes cluster, deploys sample services behind an ingress controller, runs load testing using k6, and automatically comments results on the pull request.

🧱 What's Inside
✅ CI Workflow (.github/workflows/ci.yml)

- Triggers on pull requests to the main branch.
- Provisions a multi-node KinD cluster (1 control-plane + 1 worker). 
- Installs NGINX Ingress Controller.
- Deploys two echo services (foo and bar).
- Applies ingress rules to route traffic to them via foo.localhost and bar.localhost.
- Waits for deployments to become available.
- Executes load tests using k6 and posts performance metrics as a PR comment.

⚙️ Kubernetes Cluster Config (kind/kind-config.yaml)
```
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:
  - role: control-plane
  - role: worker
```
Defines the topology of the KinD cluster.

📦 App Manifests (manifests/)

- foo.yaml and bar.yaml deploy two ealen/echo-server instances.
- ingress.yaml configures hostname-based routing via NGINX.

🧪 Load Testing Script (scripts/loadtest.js)

- Simulates randomized traffic to foo and bar endpoints.


📈 PR Comments Include
After each workflow run, a comment like the following is posted on the PR:
- Includes response times (avg, p90, p95, max).
- Requests per second.
- Error rate.

📌 Why This Matters
Validates deployments and routing inside KinD during CI.

Ensures ingress works before merging.

Provides automatic performance metrics for each PR.